### PR TITLE
Do not use "dev" as default type

### DIFF
--- a/src/Environment.php
+++ b/src/Environment.php
@@ -38,7 +38,7 @@ class Environment
      *
      * @var string $DEFAULT_TYPE
      */
-    public static $DEFAULT_TYPE = 'dev';
+    public static $DEFAULT_TYPE = 'prod';
 
     /**
      * Environment Types that should be in debug


### PR DESCRIPTION
When no type is set it defaults to "dev" which opens a major security hole, the default should be "prod" and changed to a development version when needed.